### PR TITLE
Use clientWidth instead of width for determining dolly target

### DIFF
--- a/lib/three-map-controls.js
+++ b/lib/three-map-controls.js
@@ -342,7 +342,7 @@ module.exports = (function(THREE, _){
 
         function handleUpdateDollyTrackMouse(event){
             var prevMouse = mouse.clone();
-            mouse.set(( event.clientX / domElementclientWidth ) * 2 - 1, - ( event.clientY / domElement.clientHeight ) * 2 + 1);
+            mouse.set(( event.clientX / domElement.clientWidth ) * 2 - 1, - ( event.clientY / domElement.clientHeight ) * 2 + 1);
 
             if(!prevMouse.equals(mouse)){
                 var rc = new THREE.Raycaster();
@@ -498,7 +498,7 @@ module.exports = (function(THREE, _){
             centerpoint.y = event.touches[ 0 ].pageY + (dy / 2);
 
             var mouse = new THREE.Vector2();
-            mouse.x = ( centerpoint.x / domElementclientWidth ) * 2 - 1;
+            mouse.x = ( centerpoint.x / domElement.clientWidth ) * 2 - 1;
             mouse.y = - ( centerpoint.y / domElement.clientHeight ) * 2 + 1;
 
             updateDollyTrack(mouse);

--- a/lib/three-map-controls.js
+++ b/lib/three-map-controls.js
@@ -342,7 +342,7 @@ module.exports = (function(THREE, _){
 
         function handleUpdateDollyTrackMouse(event){
             var prevMouse = mouse.clone();
-            mouse.set(( event.clientX / domElement.width ) * 2 - 1, - ( event.clientY / domElement.height ) * 2 + 1);
+            mouse.set(( event.clientX / domElementclientWidth ) * 2 - 1, - ( event.clientY / domElement.clientHeight ) * 2 + 1);
 
             if(!prevMouse.equals(mouse)){
                 var rc = new THREE.Raycaster();
@@ -498,8 +498,8 @@ module.exports = (function(THREE, _){
             centerpoint.y = event.touches[ 0 ].pageY + (dy / 2);
 
             var mouse = new THREE.Vector2();
-            mouse.x = ( centerpoint.x / domElement.width ) * 2 - 1;
-            mouse.y = - ( centerpoint.y / domElement.height ) * 2 + 1;
+            mouse.x = ( centerpoint.x / domElementclientWidth ) * 2 - 1;
+            mouse.y = - ( centerpoint.y / domElement.clientHeight ) * 2 + 1;
 
             updateDollyTrack(mouse);
         }


### PR DESCRIPTION
In Webkit, `Element.{width,height}` is unsupported and Mozilla tells you [not to use it](https://developer.mozilla.org/en/docs/Web/API/Document/width).

In practice, this means mouse dollying always works towards the center rather than at the point the user is pointing at.

`client{Width,Height}` seems to be more widely supported and solves the problem for me (tested only with Webkit)