### PR TITLE
Fix shifting zoom when scene does not take up entire document width and height

### DIFF
--- a/src/three-map-controls.js
+++ b/src/three-map-controls.js
@@ -341,7 +341,7 @@ var MapControls = function ( object, domElement, options ) {
 
         function handleUpdateDollyTrackMouse(event){
             var prevMouse = mouse.clone();
-            mouse.set(( event.clientX / domElement.clientWidth ) * 2 - 1, - ( event.clientY / domElement.clientHeight ) * 2 + 1);
+            mouse.set(( event.offsetX / domElement.clientWidth ) * 2 - 1, - ( event.offsetY / domElement.clientHeight ) * 2 + 1);
 
             if(!prevMouse.equals(mouse)){
                 var rc = new THREE.Raycaster();
@@ -356,7 +356,7 @@ var MapControls = function ( object, domElement, options ) {
 
             //console.log( 'handleMouseDownDolly' );
 
-            dollyStart.set( event.clientX, event.clientY );
+            dollyStart.set( event.offsetX, event.offsetY );
 
         }
 
@@ -364,7 +364,7 @@ var MapControls = function ( object, domElement, options ) {
 
             //console.log( 'handleMouseDownPan' );
 
-            panStart.set( event.clientX, event.clientY );
+            panStart.set( event.offsetX, event.offsetY );
 
         }
 
@@ -374,7 +374,7 @@ var MapControls = function ( object, domElement, options ) {
 
             //console.log( 'handleMouseMoveDolly' );
 
-            dollyEnd.set( event.clientX, event.clientY );
+            dollyEnd.set( event.offsetX, event.offsetY );
 
             dollyDelta.subVectors( dollyEnd, dollyStart );
 
@@ -398,7 +398,7 @@ var MapControls = function ( object, domElement, options ) {
 
             //console.log( 'handleMouseMovePan' );
 
-            panEnd.set( event.clientX, event.clientY );
+            panEnd.set( event.offsetX, event.offsetY );
 
             panDelta.subVectors( panEnd, panStart );
 


### PR DESCRIPTION
Currently the controls assume that the canvas element takes up the entire document width and height. This causes the zoom to not work properly when there is a page header or a sidebar besides the scene. If you zoom on a portion of the scene, the camera will drift away from the point where the cursor was initially.